### PR TITLE
Bump GitHub Actions to Node 16, per deprecation warning

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: GitHub token - used when getting the latest version of tflint
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'terminal'


### PR DESCRIPTION
https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/